### PR TITLE
Added materialized view support and examples

### DIFF
--- a/pivots/dynamic-pivot-create.sql
+++ b/pivots/dynamic-pivot-create.sql
@@ -4,14 +4,29 @@
  as the 2nd parameter.
  3rd parameter: name of the table or view
  4th parameter: object type:
-   'v':view, 'tv': temp view, 't': table, 'tt': temp table
+   'v':view, 'tv': temp view, 't': table, 'tt': temp table, 'm': materialized view
 
  See https://postgresql.verite.pro/blog/2018/06/19/crosstab-pivot.html
  for a lot of context about this function.
+
+ Example usage:
+    CREATE TABLE tmp1 (row_id, key, kay_value) AS
+    VALUES
+    (1, 'a', 1),
+    (1, 'b', 2),
+    (2, 'a', 3),
+    (2, 'b', 4);
+
+    SELECT dynamic_pivot_create(
+    'select row_id, key, kay_value from tmp1',
+    'select distinct key from tmp1',
+    'public.m_tmp1', 'm');
 */
-CREATE OR REPLACE FUNCTION dynamic_pivot(central_query text, headers_query text,
-   obj_name text, obj_type text default 'tv')
- RETURNS void AS
+CREATE OR REPLACE FUNCTION dynamic_pivot_create(central_query text,
+                                                headers_query text,
+                                                obj_name text,
+                                                obj_type text default 'tv')
+RETURNS void AS
 $$
 DECLARE
   left_column text;
@@ -48,10 +63,14 @@ BEGIN
   END LOOP;
 
   query := format('CREATE %s %I AS SELECT %I %s FROM (select *,row_number() over() as rn from (%s) AS _c) as _d GROUP BY %I order by min(rn)',
-           case obj_type when 't'  then 'TABLE'
+           case obj_type
+             when 't'  then 'TABLE'
 			 when 'tt' then 'TEMP TABLE'
 			 when 'v'  then 'VIEW'
 			 when 'tv' then 'TEMP VIEW'
+             when 'm'  then 'MATERIALIZED VIEW'
+             when 'mv' then 'MATERIALIZED VIEW'
+             else 'VIEW'
            end,
            obj_name,
            left_column,

--- a/pivots/dynamic-pivot-refcursor.sql
+++ b/pivots/dynamic-pivot-refcursor.sql
@@ -6,11 +6,31 @@
  will be automatically assigned.
  See https://postgresql.verite.pro/blog/2018/06/19/crosstab-pivot.html
  for a lot of context about this function.
+
+  Example usage:
+    CREATE TABLE tmp1 (row_id, key, kay_value) AS
+    VALUES
+    (1, 'a', 1),
+    (1, 'b', 2),
+    (2, 'a', 3),
+    (2, 'b', 4);
+
+    BEGIN;
+
+    SELECT dynamic_pivot_select(
+    'select row_id, key, kay_value from tmp1',
+    'select distinct key from tmp1',
+    'tmpcur');
+
+     FETCH ALL FROM "tmpcur";
+
+     COMMIT;
+
 */
-CREATE FUNCTION dynamic_pivot(central_query text,
-			      headers_query text,
-			      INOUT cname refcursor default null)
- RETURNS refcursor AS
+CREATE OR REPLACE FUNCTION dynamic_pivot_select(central_query text,
+                                                headers_query text,
+                                                INOUT cname refcursor default null)
+RETURNS REFCURSOR AS
 $$
 DECLARE
   left_column text;


### PR DESCRIPTION
1. Function names have been changed. When the names were the same, there was a conflict because both conflicting functions can take 3 arguments.
2. Added support for materialised views using `m` or `mv` as a parameter
3. Added usage examples for beginners. 